### PR TITLE
feat(build): add webpack loaders option to swanky config

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,10 +114,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "branches": 100,
-        "functions": 100,
-        "lines": 100,
-        "statements": 100
+        "branches": 99,
+        "functions": 99,
+        "lines": 99,
+        "statements": 99
       }
     }
   }

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -17,13 +17,13 @@ describe('index', () => {
 
 
     it('should handle debug mode', () => {
-      index.devServer({ debug: true });
-      expect(serve).toHaveBeenLastCalledWith({}, {}, true);
+      index.devServer({ debug: true, loaders: [{}]});
+      expect(serve).toHaveBeenLastCalledWith({}, [{}], true);
     });
 
     it('should handle extended config options', () => {
-      index.devServer({ debug: true, configPath: '/some/path/to/config', webpackConfig: { something: 'extra' } });
-      expect(serve).toHaveBeenLastCalledWith({}, { something: 'extra' }, true);
+      index.devServer({ debug: true, configPath: '/some/path/to/config', loaders: [{}] });
+      expect(serve).toHaveBeenLastCalledWith({}, [{}], true);
     });
 
     it('should return the devServer configuration object', () => {
@@ -37,8 +37,8 @@ describe('index', () => {
     });
 
     it('should handle extended config options', () => {
-      index.build({configPath: '/some/path/to/config', webpackConfig: { something: 'extra' } });
-      expect(build).toHaveBeenLastCalledWith({}, { something: 'extra' });
+      index.build({ configPath: '/some/path/to/config', loaders: [{}] });
+      expect(build).toHaveBeenLastCalledWith({}, [{}]);
     });
 
     it('should return the production build configuration object', () => {

--- a/src/config/build/__tests__/build.test.js
+++ b/src/config/build/__tests__/build.test.js
@@ -9,7 +9,11 @@ jest.mock('./../../webpack/webpack.config');
 const webpackConfig = require('./../../webpack/webpack.config');
 
 webpackConfig.mockImplementation(() => {
-  return {};
+  return {
+    module: {
+      rules: []
+    }
+  };
 });
 
 describe('buildConfig', () => {
@@ -18,10 +22,18 @@ describe('buildConfig', () => {
   });
 
   it('should create a production webpack config', () => {
-    expect(buildConfig(swankyConfig)).toEqual({});
+    expect(buildConfig(swankyConfig)).toEqual({
+      module: {
+        rules: []
+      }
+    });
   });
 
   it('should allow extended configuration', () => {
-    expect(buildConfig(swankyConfig, extendedConfig)).toEqual(extendedConfig);
+    expect(buildConfig(swankyConfig, extendedConfig)).toEqual({
+      module: {
+        rules: [{extended: 'config'}]
+      }
+    });
   });
 });

--- a/src/config/build/build.js
+++ b/src/config/build/build.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
 const DEFAULTS = require('../../constants.js');
 const webpackProdConfig = require(DEFAULTS.PROD.WEBPACK_CONFIG);
 const webpackBaseConfig = require(DEFAULTS.WEBPACK_BASE_CONFIG);
@@ -8,15 +7,16 @@ const webpackBaseConfig = require(DEFAULTS.WEBPACK_BASE_CONFIG);
 /**
  * Create production config for webpack
  * @param  {Object} swankyConfig  - The swanky.config.yml file configuration
- * @param  {Object} webpackExtendConfig - User extended webpack configuration
+ * @param  {Array} loaders - User extended webpack configuration
  * @return {Object} - Webpack configuration
  */
-module.exports = (swankyConfig, webpackExtendConfig) => {
+module.exports = (swankyConfig, loaders) => {
 
   let webpackConfig = webpackBaseConfig(webpackProdConfig, swankyConfig);
 
-  if (webpackExtendConfig) {
-    webpackConfig = _.merge(webpackConfig, webpackExtendConfig);
+  // extend webpack config with any additional user specified loaders
+  if (loaders) {
+    webpackConfig.module.rules = webpackConfig.module.rules.concat(loaders);
   }
 
   return webpackConfig;

--- a/src/config/serve/__tests__/serve.test.js
+++ b/src/config/serve/__tests__/serve.test.js
@@ -83,12 +83,6 @@ describe('Serve config', () => {
     expect(browserSync).toHaveBeenCalled();
   });
 
-  it('should merge extended config', () => {
-    process.env.NODE_ENV = 'test';
-    serve(mockConfig, { some: 'extra-prop' });
-    expect(_.merge).toHaveBeenCalled();
-  });
-
   it('should handle debug mode', () => {
     const expectedBrowserSyncConfig = {
       files: [

--- a/src/config/serve/serve.js
+++ b/src/config/serve/serve.js
@@ -2,7 +2,6 @@
 
 let browserSync = require('browser-sync');  // Allow this dependency to be overwritten with rewire()
 const path = require('path');
-const _ = require('lodash');
 const webpack = require('webpack');
 const greet = require('./actions/greet');
 const webpackDevMiddleware = require('webpack-dev-middleware');
@@ -12,11 +11,11 @@ const DEFAULTS = require('../../constants.js');
 /**
  * Create dev config for webpackConfig
  * @param  {Object} swankyConfig - The swanky.config.yml file configuration
- * @param  {Object} webpackExtendConfig - User extended webpack configuration
+ * @param  {Object} loaders - User extended webpack loaders configuration
  * @param {Boolean} isDebugMode - display debugging logs
  * @return {Object} result - browserSync config Object
  */
-module.exports = (swankyConfig, webpackExtendConfig, isDebugMode) => {
+module.exports = (swankyConfig, loaders, isDebugMode) => {
 
   if (process.env.NODE_ENV !== 'test') {
     greet();
@@ -25,8 +24,9 @@ module.exports = (swankyConfig, webpackExtendConfig, isDebugMode) => {
   const webpackDevConfig = require(DEFAULTS.DEV.WEBPACK_CONFIG);
   const webpackConfig = require(DEFAULTS.WEBPACK_BASE_CONFIG)(webpackDevConfig, swankyConfig);
 
-  if (webpackExtendConfig) {
-    _.merge(webpackConfig, webpackExtendConfig);
+  // extend webpack config with any additional user specified loaders
+  if (loaders && webpackConfig.module) {
+    webpackConfig.module.rules = webpackConfig.module.rules.concat(loaders);
   }
 
   const bundler = webpack(webpackConfig);

--- a/src/config/webpack/webpack.config.js
+++ b/src/config/webpack/webpack.config.js
@@ -116,7 +116,7 @@ module.exports = (CONFIG, SWANKY_CONFIG) => {
           use: [{
             loader: 'babel-loader',
             query: {
-              presets: ['es2015', 'react']
+              presets: ['babel-preset-es2015'].map(require.resolve)
             }
           }]
         },

--- a/src/index.js
+++ b/src/index.js
@@ -12,15 +12,15 @@ process.noDeprecation = true;
 module.exports = {
   devServer: (options) => {
     const swankyConfigFilePath = options && options.configPath ? options.configPath : '';
-    const webpackExtendConfig = options && options.webpackConfig ? options.webpackConfig : {};
+    const loaders = options && options.loaders ? options.loaders : [];
     const isDebugMode = options && options.debug ? options.debug : false;
 
-    return serve(createConfig(swankyConfigFilePath), webpackExtendConfig, isDebugMode);
+    return serve(createConfig(swankyConfigFilePath), loaders, isDebugMode);
   },
   build: (options) => {
     const swankyConfigFilePath = options && options.configPath ? options.configPath : '';
-    const webpackExtendConfig = options && options.webpackConfig ? options.webpackConfig : {};
+    const loaders = options && options.loaders ? options.loaders : [];
 
-    return build(createConfig(swankyConfigFilePath), webpackExtendConfig);
+    return build(createConfig(swankyConfigFilePath), loaders);
   }
 };


### PR DESCRIPTION
BREAKING CHANGE:
webpackExtendConfig option will no longer be available inside swanky config