### PR TITLE
fix(build): remove html-loader minification settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "jest-cli": "22.4.3",
     "npm-run-all": "4.1.2",
     "rimraf": "2.6.2",
-    "semantic-release": "15.1.4",
+    "semantic-release": "6.3.2",
     "stringstream": "0.0.5"
   },
   "engines": {

--- a/src/config/webpack/webpack.config.js
+++ b/src/config/webpack/webpack.config.js
@@ -156,13 +156,6 @@ module.exports = (CONFIG, SWANKY_CONFIG) => {
       new webpack.LoaderOptionsPlugin({
         options: {
           context: path.resolve(path.join(SWANKY_CONFIG.meta.theme, DEFAULTS.CSS_THEME_FOLDER)),
-          htmlLoader: {
-            minimize: true,
-            removeAttributeQuotes: false,
-            caseSensitive: true,
-            customAttrSurround: [ [/#/, /(?:)/], [/\*/, /(?:)/], [/\[?\(?/, /(?:)/] ],
-            customAttrAssign: [ /\)?\]?=/ ]
-          },
           swankyDocs: {
             sections: SECTIONS_CONFIG
           }


### PR DESCRIPTION
minification causing issues when parsing jsdoc style comments `@example`

ISSUES CLOSED: #43